### PR TITLE
Fix deprecation warnings

### DIFF
--- a/server/connect.js
+++ b/server/connect.js
@@ -1,13 +1,18 @@
-const mongoose = require('mongoose');
+const mongoose = require("mongoose");
+
 // mongo connection
+
+mongoose.set("useCreateIndex", true);
+mongoose.set("useFindAndModify", false);
+
 const uri = process.env.ATLAS_URI;
 mongoose.Promise = global.Promise;
 mongoose.connect(uri, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
 });
 
 const connection = mongoose.connection;
-connection.once('open', ()=>{
-  console.log('connected')
-})
+connection.once("open", () => {
+  console.log("connected");
+});

--- a/server/controllers/friendsControllers.js
+++ b/server/controllers/friendsControllers.js
@@ -144,7 +144,7 @@ exports.followFriend = async (req, res) => {
     )
       throw new Error("Already follow/sent");
 
-    await Friends.update({ userId }, { $push: { sent: friendId } });
+    await Friends.updateOne({ userId }, { $push: { sent: friendId } });
 
     // change friend's followers status
     let followingFriends = await Friends.findOne({ userId: friendId });
@@ -156,7 +156,7 @@ exports.followFriend = async (req, res) => {
     )
       throw new Error("Something went wrong...");
 
-    await Friends.update({ userId: friendId }, { $push: { received: userId } });
+    await Friends.updateOne({ userId: friendId }, { $push: { received: userId } });
 
     res.json({ message: `Request sent to ${friendId} successfully` });
   } catch (err) {
@@ -174,13 +174,13 @@ exports.unfollowFriend = async (req, res) => {
     const myFriends = await Friends.findOne({ userId });
     if (!myFriends) throw new Error("Not following");
 
-    await Friends.update({ userId }, { $pull: { followings: friendId } });
+    await Friends.updateOne({ userId }, { $pull: { followings: friendId } });
 
     // remove user from friend's followers
     const followersFriends = await Friends.findOne({ userId: friendId });
     if (!followersFriends) throw new Error("Not follower");
 
-    await Friends.update(
+    await Friends.updateOne(
       { userId: friendId },
       { $pull: { followers: userId } }
     );

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -39,7 +39,7 @@ router.post("/", async (req, res) => {
     user.password = await bcrypt.hash(user.password, salt);
     await user.save();
     const token = jwt.sign({ _id: user._id }, process.env.jwtPrivateKey);
-    res.send({ user, token });
+    res.status(201).send({ user, token });
   } catch (err) {
     console.log(err);
     res.status(400).send(err.toString());


### PR DESCRIPTION
DeprecationWarning: Mongoose: `findOneAndUpdate()` and `findOneAndDelete()` without the `useFindAndModify` option set to false are deprecated. See: https://mongoosejs.com/docs/deprecations.html#findandmodify
